### PR TITLE
Add CarbonImmutable Cast Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,10 @@
     "scripts": {
         "test": "./vendor/bin/pest",
         "stan": "./vendor/bin/phpstan analyse"
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
 }

--- a/src/HasProperties.php
+++ b/src/HasProperties.php
@@ -2,6 +2,7 @@
 
 namespace Based\Fluent;
 
+use Carbon\CarbonImmutable;
 use Based\Fluent\Casts\AbstractCaster;
 use Based\Fluent\Casts\Cast;
 use Based\Fluent\Relations\AbstractRelation;
@@ -192,6 +193,7 @@ trait HasProperties
         return match ($type) {
             Collection::class => 'collection',
             Carbon::class => 'datetime',
+            CarbonImmutable::class => 'immutable_datetime',
             'bool' => 'boolean',
             'int' => 'integer',
             default => $type,

--- a/tests/Pest/CastsTest.php
+++ b/tests/Pest/CastsTest.php
@@ -100,6 +100,21 @@ test('cast as datetime (carbon)', function () {
     assertEquals($model->getAttribute('carbon'), $model->carbon);
 });
 
+test('cast as immutable_datetime (carbon)', function () {
+    $date = now()->startOfDay()->toImmutable();
+
+    $model = new FluentModel([
+        'carbon_immutable' => $date,
+    ]);
+
+    $model->save();
+
+    assertDatabaseCount('fluent_models', 1);
+    assertEquals($model->getAttribute('carbon_immutable'), $model->carbon_immutable);
+    assertEquals($date, $model->carbon_immutable);
+    assertEquals('immutable_datetime', $model->getCasts()['carbon_immutable']);
+});
+
 test('cast as boolean', function () {
     $model = new FluentModel([
         'boolean' => true,

--- a/tests/Pest/Models/FluentModel.php
+++ b/tests/Pest/Models/FluentModel.php
@@ -2,6 +2,7 @@
 
 namespace Based\Fluent\Tests\Models;
 
+use Carbon\CarbonImmutable;
 use Based\Fluent\Casts\AsDecimal;
 use Based\Fluent\Casts\Cast;
 use Based\Fluent\Fluent;
@@ -20,6 +21,7 @@ class FluentModel extends Model
     public array $array;
     public Collection $collection;
     public Carbon $carbon;
+    public CarbonImmutable $carbon_immutable;
     public bool $boolean;
     public ?array $nullable_array;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ class TestCase extends TestbenchTestCase
             $table->json('array')->nullable();
             $table->json('collection')->nullable();
             $table->timestamp('carbon')->nullable();
+            $table->timestamp('carbon_immutable')->nullable();
             $table->boolean('boolean')->nullable();
             $table->decimal('decimal')->nullable();
             $table->decimal('as_decimal')->nullable();


### PR DESCRIPTION
This PR add `CarbonImmutable `cast support, as it is natively supported by  Laravel as `immutable_datetime`
I think this PR is important for programmers like me as the packages is unusable to cast dates when using 
`Date::use(CarbonImmutable::class);`
as all dates and datetimes will be instance of `CarbonImmutable`